### PR TITLE
hotfix: auto tag package version fixed

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           token: "${{ secrets.GH_AUTH_TOKEN }}"
           fetch-depth: 0
-      - uses: butlerlogic/action-autotag@master
+      - uses: butlerlogic/action-autotag@1.1.2
         with:
           GITHUB_TOKEN: "${{ secrets.GH_AUTH_TOKEN }}"
           tag_prefix: "v"


### PR DESCRIPTION
## Parent PR
https://github.com/Iconscout/react-unicons-solid/pull/35

## Error in action
 ![image](https://github.com/user-attachments/assets/ef1954bc-e63c-49da-9f74-58849bcaa095)

## Refer the same issue on action-autotag repo:  
https://github.com/ButlerLogic/action-autotag/issues/49

## Changes made
Used spacific working version of action-autotag