### PR TITLE
feat: added react 19 support and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 lib
 
 .npmrc
+.DS_Store
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules
 example
+.DS_Store

--- a/build/generate.js
+++ b/build/generate.js
@@ -13,24 +13,26 @@ fs.mkdirSync(iconsComponentPath)
 
 const indexJs = []
 
-uniconsConfig.forEach(icon => {
+uniconsConfig.forEach((icon) => {
   const baseName = `uis-${icon.name}`
   const location = path.join(iconsComponentPath, `${baseName}.js`)
   const name = upperCamelCase(baseName)
-  const svgFile = fs.readFileSync(path.resolve('node_modules/@iconscout/unicons', icon.svg), 'utf-8')
+  const svgFile = fs.readFileSync(
+    path.resolve('node_modules/@iconscout/unicons', icon.svg),
+    'utf-8'
+  )
 
   let data = svgFile.replace(/<svg[^>]+>/gi, '').replace(/<\/svg>/gi, '')
   // Get Path Content from SVG
   const $ = cheerio.load(data, {
-    xmlMode: true
+    xmlMode: true,
   })
   const svgPath = $('path').attr('d')
 
   const template = `import React from 'react';
 import PropTypes from 'prop-types';
 
-const ${name} = (props) => {
-  const { color, size, ...otherProps } = props
+const ${name} = ({ color = 'currentColor', size = 24, ...otherProps }) => {  
   return React.createElement('svg', {
     xmlns: 'http://www.w3.org/2000/svg',
     width: size,
@@ -46,11 +48,6 @@ const ${name} = (props) => {
 ${name}.propTypes = {
   color: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
-
-${name}.defaultProps = {
-  color: 'currentColor',
-  size: '24',
 };
 
 export default ${name};`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@iconscout/react-unicons-solid",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "IconScout Digital License",
       "dependencies": {
-        "react": ">=15.0.0 <17.0.0"
+        "prop-types": "^15.8.1"
       },
       "devDependencies": {
         "@iconscout/unicons": "^4.0.7",
@@ -20,7 +20,7 @@
         "webpack-cli": "^5.1.4"
       },
       "peerDependencies": {
-        "react": ">=15.0.0 <17.0.0"
+        "react": ">=15.0.0 <20.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -3897,15 +3897,11 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iconscout/react-unicons-solid",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,6 @@
     "type": "git",
     "url": "git+https://github.com/Iconscout/react-unicons-solid.git"
   },
-  "peerDependencies": {
-    "react": ">=15.0.0 <17.0.0"
-  },
-  "dependencies": {
-    "react": ">=15.0.0 <17.0.0"
-  },
   "keywords": [
     "unicons",
     "react-unicons-solid",
@@ -43,5 +37,11 @@
     "uppercamelcase": "^3.0.0",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "prop-types": "^15.8.1"
+  },
+  "peerDependencies": {
+    "react": ">=15.0.0 <20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iconscout/react-unicons-solid",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "4,500+ vector solid icons as easy to use React Components",
   "main": "./lib/cjs/index.js",
   "module": "./index.js",


### PR DESCRIPTION
### Release Notes

- **React Support:** Extended both peer dependency and supported versions for React up to v19, ensuring compatibility with the latest React releases.
- This will now fix the issue with currentColor fallback that was not working in last release
- **Dependencies:** Added `prop-types` as after React 16, its removed from default
- **Component Generation:** Refactored the icon component generator:
  - Now uses function parameters with default values for `color` and `size`, removing the need for `defaultProps`.
  - Code is simplified and more consistent with modern React practices.

These updates improve compatibility, simplify generated components, and enhance type safety.

Refer similar changes in React Unicons package https://github.com/Iconscout/react-unicons/pull/125